### PR TITLE
feat(resolution): support NuGet cache as assembly resolution source

### DIFF
--- a/DotNetMetadataMcpServer/Configuration/AssemblyResolutionMode.cs
+++ b/DotNetMetadataMcpServer/Configuration/AssemblyResolutionMode.cs
@@ -1,0 +1,8 @@
+namespace DotNetMetadataMcpServer.Configuration;
+
+public enum AssemblyResolutionMode
+{
+    BuildOutput,
+    NuGetCache,
+    Auto
+}

--- a/DotNetMetadataMcpServer/Configuration/ToolsConfiguration.cs
+++ b/DotNetMetadataMcpServer/Configuration/ToolsConfiguration.cs
@@ -3,9 +3,10 @@ namespace DotNetMetadataMcpServer.Configuration;
 public class ToolsConfiguration
 {
     public const string SectionName = "Tools";
-    
+
     public int DefaultPageSize { get; set; } = 20;
     public bool IntendResponse { get; set; } = true;
+    public AssemblyResolutionMode AssemblyResolutionMode { get; set; } = AssemblyResolutionMode.BuildOutput;
     public List<NuGetSourceConfiguration> NuGetSources { get; set; } = new()
     {
         new NuGetSourceConfiguration

--- a/DotNetMetadataMcpServer/DependenciesScanner.cs
+++ b/DotNetMetadataMcpServer/DependenciesScanner.cs
@@ -1,8 +1,10 @@
 using System.Reflection;
 using System.Runtime.Loader;
 using DependencyGraph.Core.Graph;
+using DotNetMetadataMcpServer.Configuration;
 using Microsoft.Build.Locator;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using NuGet.ProjectModel;
 
 namespace DotNetMetadataMcpServer;
@@ -13,22 +15,26 @@ public class DependenciesScanner : IDependenciesScanner
     private readonly ReflectionTypesCollector _reflection;
     private readonly ILogger _nuGetLogger;
     private readonly ILogger<DependenciesScanner> _logger;
+    private readonly AssemblyResolutionMode _resolutionMode;
 
     private readonly HashSet<IDependencyGraphNode> _visitedNodes = new();
 
     private string _baseDir = "";
+    private string _globalPackagesFolder = "";
 
     public DependenciesScanner(
         MsBuildHelper msBuildHelper,
         ReflectionTypesCollector reflectionTypesCollector,
+        IOptions<ToolsConfiguration>? toolsConfiguration = null,
         ILogger<DependenciesScanner>? logger = null,
         ILogger<LockFileFormat>? nuGetLogger = null)
     {
         _msbuild = msBuildHelper;
         _reflection = reflectionTypesCollector;
+        _resolutionMode = toolsConfiguration?.Value.AssemblyResolutionMode ?? AssemblyResolutionMode.BuildOutput;
         _nuGetLogger = nuGetLogger ?? NullLogger<LockFileFormat>.Instance;
         _logger = logger ?? NullLogger<DependenciesScanner>.Instance;
-        
+
         AppDomain.CurrentDomain.AssemblyResolve += ResolveAssembly;
     }
 
@@ -48,7 +54,7 @@ public class DependenciesScanner : IDependenciesScanner
         }
 
         var (asmPath, assetsPath, tfm) = _msbuild.EvaluateProject(csprojPath);
-        
+
         _baseDir = Path.GetDirectoryName(asmPath) ?? "";
 
         var projectName = Path.GetFileNameWithoutExtension(csprojPath);
@@ -61,9 +67,21 @@ public class DependenciesScanner : IDependenciesScanner
         var depList = new List<DependencyInfo>();
         pm.Dependencies = depList;
 
-        // 1) Load public types from the project itself
-        var projectTypes = _reflection.LoadAssemblyTypes(asmPath);
-        pm.ProjectTypes.AddRange(projectTypes);
+        // 1) Load public types from the project itself (skip gracefully if not built)
+        if (File.Exists(asmPath))
+        {
+            var projectTypes = _reflection.LoadAssemblyTypes(asmPath);
+            pm.ProjectTypes.AddRange(projectTypes);
+        }
+        else if (_resolutionMode != AssemblyResolutionMode.BuildOutput)
+        {
+            _logger.LogInformation(
+                "Project assembly not found at {Path}. Skipping project types (NuGet cache mode).", asmPath);
+        }
+        else
+        {
+            _logger.LogWarning("Project assembly not found at {Path}.", asmPath);
+        }
 
         // 2) If there is no assetsFile, skip dependencies
         if (string.IsNullOrEmpty(assetsPath) || !File.Exists(assetsPath))
@@ -72,18 +90,23 @@ public class DependenciesScanner : IDependenciesScanner
             return pm;
         }
 
-        // 3) Build DependencyGraph
+        // 3) Parse lock file and extract global packages folder
         var lockFileFormat = new LockFileFormat();
         var lockFile = lockFileFormat.Read(assetsPath, new MicrosoftLoggerAdapter(_nuGetLogger));
-        
-        
+
+        _globalPackagesFolder = lockFile.PackageFolders.FirstOrDefault()?.Path ?? "";
+        if (string.IsNullOrEmpty(_globalPackagesFolder))
+        {
+            _logger.LogWarning("Could not determine NuGet global packages folder from lock file.");
+        }
+
         var theFirstTarget = lockFile.Targets.FirstOrDefault();
         if (theFirstTarget == null)
         {
             _logger.LogWarning("No targets found in lock file.");
             return pm;
         }
-        
+
         foreach (var lib in theFirstTarget.Libraries)
         {
             var d = BuildDependencyInfo(lib);
@@ -128,8 +151,13 @@ public class DependenciesScanner : IDependenciesScanner
         foreach (var lockFileItem in lockFileTargetLibrary.RuntimeAssemblies)
         {
             var rel = lockFileItem.Path; // e.g., "lib/net9.0/FluentValidation.dll"
-            var fileName = Path.GetFileName(rel);
-            var full = Path.Combine(_baseDir, fileName);
+            var full = ResolveAssemblyPath(lockFileTargetLibrary, rel);
+            if (full == null)
+            {
+                _logger.LogDebug("Could not resolve assembly path for {Name} ({Path})",
+                    lockFileTargetLibrary.Name, rel);
+                continue;
+            }
             var types = _reflection.LoadAssemblyTypes(full);
             var info = new DependencyInfo
             {
@@ -142,6 +170,54 @@ public class DependenciesScanner : IDependenciesScanner
         }
 
         return result;
+    }
+
+    private string? ResolveAssemblyPath(LockFileTargetLibrary lib, string relativePath)
+    {
+        var fileName = Path.GetFileName(relativePath);
+        var packageName = lib.Name ?? "";
+        var packageVersion = lib.Version?.ToNormalizedString() ?? "";
+
+        switch (_resolutionMode)
+        {
+            case AssemblyResolutionMode.BuildOutput:
+            {
+                var path = Path.Combine(_baseDir, fileName);
+                return File.Exists(path) ? path : null;
+            }
+            case AssemblyResolutionMode.NuGetCache:
+            {
+                return ResolveFromNuGetCache(packageName, packageVersion, relativePath);
+            }
+            case AssemblyResolutionMode.Auto:
+            {
+                var buildPath = Path.Combine(_baseDir, fileName);
+                if (File.Exists(buildPath))
+                    return buildPath;
+                return ResolveFromNuGetCache(packageName, packageVersion, relativePath);
+            }
+            default:
+                return null;
+        }
+    }
+
+    private string? ResolveFromNuGetCache(string packageName, string packageVersion, string relativePath)
+    {
+        if (string.IsNullOrEmpty(_globalPackagesFolder))
+            return null;
+
+        // NuGet cache layout: {globalPackagesFolder}/{packageId.ToLower()}/{version}/{relativePath}
+        var cachePath = Path.Combine(
+            _globalPackagesFolder,
+            packageName.ToLowerInvariant(),
+            packageVersion,
+            relativePath.Replace('/', Path.DirectorySeparatorChar));
+
+        if (File.Exists(cachePath))
+            return cachePath;
+
+        _logger.LogDebug("Assembly not found in NuGet cache: {Path}", cachePath);
+        return null;
     }
     
     
@@ -196,9 +272,9 @@ public class DependenciesScanner : IDependenciesScanner
                 {
                     foreach (var asmItem in pkgNode.TargetLibrary.RuntimeAssemblies)
                     {
-                        var rel = asmItem.Path; // e.g., "lib/net9.0/FluentValidation.dll"
-                        var fileName = Path.GetFileName(rel);
-                        var full = Path.Combine(_baseDir, fileName);
+                        var rel = asmItem.Path;
+                        var full = ResolveAssemblyPath(pkgNode.TargetLibrary, rel);
+                        if (full == null) continue;
                         var types = _reflection.LoadAssemblyTypes(full);
                         info.Types.AddRange(types);
                     }

--- a/DotNetMetadataMcpServer/appsettings.json
+++ b/DotNetMetadataMcpServer/appsettings.json
@@ -2,6 +2,7 @@
   "Tools": {
     "DefaultPageSize": 20,
     "IntendResponse": false,
+    "AssemblyResolutionMode": "BuildOutput",
     "NuGetSources": [
       {
         "Name": "nuget.org",

--- a/MetadataExplorerTest/AssemblyResolutionModeTests.cs
+++ b/MetadataExplorerTest/AssemblyResolutionModeTests.cs
@@ -1,0 +1,170 @@
+using DotNetMetadataMcpServer;
+using DotNetMetadataMcpServer.Configuration;
+using DotNetMetadataMcpServer.Services;
+using Microsoft.Extensions.Options;
+
+namespace MetadataExplorerTest;
+
+[TestFixture]
+[NonParallelizable]
+public class AssemblyResolutionModeTests
+{
+    private string _testProjectPath;
+
+    [SetUp]
+    public void Setup()
+    {
+        var testDirectory = TestContext.CurrentContext.TestDirectory;
+        var relativePath = Path.Combine(testDirectory, "../../../../DotNetMetadataMcpServer/DotNetMetadataMcpServer.csproj");
+        _testProjectPath = Path.GetFullPath(relativePath);
+
+        if (!File.Exists(_testProjectPath))
+            Assert.Inconclusive("Test project file not found: " + _testProjectPath);
+    }
+
+    [Test]
+    public void BuildOutput_Mode_ShouldResolveAssembliesFromBinDirectory()
+    {
+        var config = Options.Create(new ToolsConfiguration
+        {
+            AssemblyResolutionMode = AssemblyResolutionMode.BuildOutput
+        });
+        using var scanner = new DependenciesScanner(
+            new MsBuildHelper(), new ReflectionTypesCollector(), config);
+
+        var service = new AssemblyToolService(scanner);
+        var response = service.GetAssemblies(_testProjectPath, new List<string>(), 1, 50);
+
+        Assert.That(response.AssemblyNames, Is.Not.Null);
+        Assert.That(response.AssemblyNames.Count, Is.GreaterThan(0));
+    }
+
+    [Test]
+    public void NuGetCache_Mode_ShouldResolveAssembliesFromGlobalPackagesFolder()
+    {
+        var config = Options.Create(new ToolsConfiguration
+        {
+            AssemblyResolutionMode = AssemblyResolutionMode.NuGetCache
+        });
+        using var scanner = new DependenciesScanner(
+            new MsBuildHelper(), new ReflectionTypesCollector(), config);
+
+        var service = new AssemblyToolService(scanner);
+        var response = service.GetAssemblies(_testProjectPath, new List<string>(), 1, 50);
+
+        Assert.That(response.AssemblyNames, Is.Not.Null);
+        Assert.That(response.AssemblyNames.Count, Is.GreaterThan(0),
+            "NuGetCache mode should resolve assemblies from the global packages folder");
+    }
+
+    [Test]
+    public void NuGetCache_Mode_ShouldLoadTypesFromResolvedAssemblies()
+    {
+        var config = Options.Create(new ToolsConfiguration
+        {
+            AssemblyResolutionMode = AssemblyResolutionMode.NuGetCache
+        });
+        using var scanner = new DependenciesScanner(
+            new MsBuildHelper(), new ReflectionTypesCollector(), config);
+
+        var assemblyService = new AssemblyToolService(scanner);
+        var assemblies = assemblyService.GetAssemblies(_testProjectPath, new List<string>(), 1, 200);
+
+        // Pick an assembly that should have types (e.g. a well-known NuGet package)
+        var serilogAssembly = assemblies.AssemblyNames.FirstOrDefault(a =>
+            a.Contains("Serilog", StringComparison.OrdinalIgnoreCase) && !a.Contains("Sinks"));
+
+        Assert.That(serilogAssembly, Is.Not.Null,
+            "Serilog should be among referenced assemblies");
+
+        var namespaceService = new NamespaceToolService(scanner);
+        var namespaces = namespaceService.GetNamespaces(
+            _testProjectPath, new List<string> { serilogAssembly! }, new List<string>(), 1, 50);
+
+        Assert.That(namespaces.Namespaces, Is.Not.Empty,
+            "Should find namespaces in the Serilog assembly resolved from NuGet cache");
+    }
+
+    [Test]
+    public void Auto_Mode_ShouldResolveAssemblies()
+    {
+        var config = Options.Create(new ToolsConfiguration
+        {
+            AssemblyResolutionMode = AssemblyResolutionMode.Auto
+        });
+        using var scanner = new DependenciesScanner(
+            new MsBuildHelper(), new ReflectionTypesCollector(), config);
+
+        var service = new AssemblyToolService(scanner);
+        var response = service.GetAssemblies(_testProjectPath, new List<string>(), 1, 50);
+
+        Assert.That(response.AssemblyNames, Is.Not.Null);
+        Assert.That(response.AssemblyNames.Count, Is.GreaterThan(0));
+    }
+
+    [Test]
+    public void NuGetCache_Mode_ShouldSkipProjectTypesGracefully_WhenNotBuilt()
+    {
+        // This test verifies the scanner doesn't crash when project assembly is missing.
+        // We can't easily simulate a missing build, but we verify the scanner
+        // handles the scenario by checking it produces results even in NuGetCache mode.
+        var config = Options.Create(new ToolsConfiguration
+        {
+            AssemblyResolutionMode = AssemblyResolutionMode.NuGetCache
+        });
+        using var scanner = new DependenciesScanner(
+            new MsBuildHelper(), new ReflectionTypesCollector(), config);
+
+        var metadata = scanner.ScanProject(_testProjectPath);
+
+        Assert.That(metadata, Is.Not.Null);
+        Assert.That(metadata.ProjectName, Is.Not.Empty);
+        Assert.That(metadata.Dependencies, Is.Not.Empty,
+            "Should still resolve NuGet dependencies even if project assembly handling differs");
+    }
+
+    [Test]
+    public void Default_Configuration_ShouldUseBuildOutputMode()
+    {
+        var config = new ToolsConfiguration();
+        Assert.That(config.AssemblyResolutionMode, Is.EqualTo(AssemblyResolutionMode.BuildOutput));
+    }
+
+    [Test]
+    public void NuGetCache_And_BuildOutput_ShouldFindSameAssemblies()
+    {
+        // Both modes should discover the same set of referenced assemblies
+        var buildConfig = Options.Create(new ToolsConfiguration
+        {
+            AssemblyResolutionMode = AssemblyResolutionMode.BuildOutput
+        });
+        var cacheConfig = Options.Create(new ToolsConfiguration
+        {
+            AssemblyResolutionMode = AssemblyResolutionMode.NuGetCache
+        });
+
+        List<string> buildAssemblies;
+        using (var scanner = new DependenciesScanner(
+            new MsBuildHelper(), new ReflectionTypesCollector(), buildConfig))
+        {
+            var service = new AssemblyToolService(scanner);
+            buildAssemblies = service.GetAssemblies(_testProjectPath, new List<string>(), 1, 200).AssemblyNames.ToList();
+        }
+
+        List<string> cacheAssemblies;
+        using (var scanner = new DependenciesScanner(
+            new MsBuildHelper(), new ReflectionTypesCollector(), cacheConfig))
+        {
+            var service = new AssemblyToolService(scanner);
+            cacheAssemblies = service.GetAssemblies(_testProjectPath, new List<string>(), 1, 200).AssemblyNames.ToList();
+        }
+
+        Assert.That(buildAssemblies, Is.Not.Empty);
+        Assert.That(cacheAssemblies, Is.Not.Empty);
+
+        // NuGet cache mode should find at least as many assemblies as build output
+        // (build output might miss some if not all were copied)
+        Assert.That(cacheAssemblies.Count, Is.GreaterThanOrEqualTo(buildAssemblies.Count * 0.8),
+            "NuGet cache mode should find a comparable number of assemblies");
+    }
+}

--- a/MetadataExplorerTest/Integration/ScopedServicesLifecycleTests.cs
+++ b/MetadataExplorerTest/Integration/ScopedServicesLifecycleTests.cs
@@ -142,7 +142,7 @@ public class ScopedServicesLifecycleTests : McpServerIntegrationTestBase
             MsBuildHelper msBuildHelper,
             ReflectionTypesCollector reflectionTypesCollector,
             Microsoft.Extensions.Logging.ILogger<DependenciesScanner> logger)
-            : base(msBuildHelper, reflectionTypesCollector, logger)
+            : base(msBuildHelper, reflectionTypesCollector, logger: logger)
         {
             // Construction is already tracked in the factory method
         }

--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,7 @@ Contributions are welcome! Please feel free to submit a Pull Request.
   - Events with handler types
 - **NuGet Package Search**: Search for NuGet packages on nuget.org with filtering and pagination
 - **NuGet Package Version Information**: Retrieve version history and dependency information for specific NuGet packages
+- **Configurable Assembly Resolution**: Resolve assemblies from build output, NuGet global packages cache (restore-only, no build required), or automatically try both
 - **Filtering**: Apply wildcard filters to narrow down results
 - **Pagination**: Handle large result sets with built-in pagination
 
@@ -107,6 +108,26 @@ When the same package is found in multiple sources, the server uses a **priority
 }
 ```
 In this configuration, if a package exists in both sources, information from "Internal" will be used.
+
+### Assembly Resolution Mode
+
+The server supports different strategies for locating package assemblies. Configure this in `appsettings.json`:
+
+```json
+{
+  "Tools": {
+    "AssemblyResolutionMode": "NuGetCache"
+  }
+}
+```
+
+| Mode | Behavior |
+|-|-|
+| `BuildOutput` | Default. Resolve assemblies from the build output directory (e.g. `bin/Debug/net9.0/`). Requires a full build. |
+| `NuGetCache` | Resolve assemblies directly from the NuGet global packages cache. Only requires `dotnet restore`, no build needed. Project types are skipped gracefully. |
+| `Auto` | Try build output first, fall back to NuGet cache if the assembly is not found in the build output. |
+
+The `NuGetCache` mode is particularly useful when you primarily need to explore third-party package APIs without waiting for a full build cycle. The global packages folder path is read from `project.assets.json` automatically.
 
 ## Installation
 
@@ -204,7 +225,7 @@ Replace `/path/to/your/dotnet/projects` with the directory containing your .NET 
 
 ## Important Limitations
 
-- **The project must be built before scanning.** The server relies on compiled assemblies to extract type information, so make sure to build your project before using the tools.
+- **Build requirement depends on resolution mode.** In `BuildOutput` mode (default), the project must be built before scanning. In `NuGetCache` mode, only `dotnet restore` is required — the server resolves package assemblies directly from the NuGet global packages cache. Project-specific types are only available when the project has been built.
 - **The tool doesn't follow references to other projects.** It only inspects the specified project and its NuGet dependencies. If you need to analyze multiple projects, you'll need to scan each one separately.
 
 ### How project outputs are located


### PR DESCRIPTION
Add configurable AssemblyResolutionMode (BuildOutput/NuGetCache/Auto) to resolve package assemblies directly from the NuGet global packages cache after dotnet restore, without requiring a full build.

Closes #2